### PR TITLE
Finally get the break timer properly functional

### DIFF
--- a/breaktimer.koplugin/main.lua
+++ b/breaktimer.koplugin/main.lua
@@ -433,7 +433,7 @@ function BreakTimer:onResume()
         logger.dbg("BreakTimer: onResume with an active timer")
         -- If we were suspended for at least the length of a break, reset the break period.
         -- It doesn't matter whether a break was currently active or not.
-        local time_idle_s = time.to_s(self.now() - self.idle_start)
+        local time_idle_s = time.to_s(time.now() - self.idle_start)
         logger.dbg(string.format("BreakTimer: Was idle for %d seconds", time_idle_s))
         if time_idle_s >= self.break_length then
             logger.dbg(string.format("BreakTimer: Idle time (%d seconds) was greater than or equal to the break length (%d seconds), resetting break", time_idle_s, self.break_length))


### PR DESCRIPTION
Use a bool instead of checking if break dialog is nil.
Ignore spurious callbacks that occur before the scheduled event.
Call unschedule multiple times to be safe.

There are probably still some bugs left to be worked out.